### PR TITLE
2.4.0

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Publish Python 🐍 distribution 📦 to PyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/onc
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,67 @@
 # Changelog
 
-## v2.3.5 and before
+## v2.4.0 (2024-05-30)
+
+### Enhancements
+
+- Improved package setup (pyproject.toml, linting and formatter).
+  ([#1](https://github.com/OceanNetworksCanada/api-python-client/issues/1))
+- Added support of Path type for outPath (instance variable in ONC class).
+  ([#12](https://github.com/OceanNetworksCanada/api-python-client/issues/12))
+- Added GitHub Actions for continuous integration.
+  ([#19](https://github.com/OceanNetworksCanada/api-python-client/issues/19))
+- Added Sphinx for generating documentation.
+  ([#7](https://github.com/OceanNetworksCanada/api-python-client/issues/7))
+- Improved exception types raised and caught.
+  ([#17](https://github.com/OceanNetworksCanada/api-python-client/issues/17))
+- Added new public methods (`checkDataProduct`, `cancelDataProduct`, `restartDataProduct`, `getSensorCategoryCodes`) to match backend API update.
+  ([#26](https://github.com/OceanNetworksCanada/api-python-client/issues/26))
+- Renamed some public methods (old names are still available) to make the naming more consistent with the api end points.
+  ([#33](https://github.com/OceanNetworksCanada/api-python-client/issues/33))
+
+| API End Point         | Old Name               | New Name                  |
+| --------------------- | ---------------------- | ------------------------- |
+| /locations/tree       | getLocationHierarchy   | getLocationsTree          |
+| /scalardata/location  | getDirectByLocation    | getScalardataByLocation   |
+| /scalardata/device    | getDirectByDevice      | getScalardataByDevice     |
+| /rawdata/location     | getDirectRawByLocation | getRawdataByLocation      |
+| /rawdata/device       | getDirectRawByDevice   | getRawdataByDevice        |
+| /archivefile/location | getListByLocation      | getArchivefileByLocation  |
+| /archivefile/device   | getListByDevice        | getArchivefileByDevice    |
+| /archivefile/download | getFile                | downloadArchivefile       |
+| N/A                   | getDirectFiles         | downloadDirectArchivefile |
+
+- Added helper methods to combine `getXXXByLocation` and `getXXXByDevice` into `getXXX`.
+  ([#33](https://github.com/OceanNetworksCanada/api-python-client/issues/33))
+  - Namely, `getScalardata`, `getRawdata` and `getArchivefile`.
+
+### Fixes
+
+- Removed unused modules (onc/ags.py, onc/dap.py, onc/nerc.py, onc/sos.py).
+  ([#1](https://github.com/OceanNetworksCanada/api-python-client/issues/1))
+
+### Tests
+
+- Added support using .env file for storing the token when running tests.
+  ([#2](https://github.com/OceanNetworksCanada/api-python-client/issues/2))
+- Replaced robot framework with pytest.
+  ([#10](https://github.com/OceanNetworksCanada/api-python-client/issues/10))
 
 ### Contributors
 
-- Dany Cabrera
+- [Jacob Stevens-Haas](https://github.com/Jacob-Stevens-Haas)
+- [Kan Fu](https://github.com/kan-fu)
+- [Renfu Li](https://github.com/Renfu-Li)
+
+### Reviewers panel
+
+- [Angela Schlesinger](https://github.com/aschlesin)
+- [Eli Ferguson](https://github.com/eliferguson)
+- [Jacob Stevens-Haas](https://github.com/Jacob-Stevens-Haas)
+- [Spencer Plovie](https://github.com/spencerwplovie)
+
+## v2.3.5 (2019-12-12) and before
+
+### Contributors
+
+- [Dany Alejandro Cabrera](https://github.com/danyalejandro)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -9,7 +9,7 @@
 project = "onc"
 copyright = "2024, ONC Data Team"
 author = "ONC Data Team"
-release = "2.3.5"
+release = "2.4.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "onc"
-version = "2.3.5"
-description = "Ocean 3.0 API Python Client Library"
+version = "2.4.0"
+description = "Oceans 3.0 API Python Client Library"
 readme = "README.md"
 authors = [
-    { name = "ONC Data Team", email = "data@oceannetworks.ca" },
+    { name = "ONC Data Team", email = "api_support@oceannetworks.ca" },
 ]
 license = { file = 'LICENSE.txt' }
 requires-python = ">=3.9"


### PR DESCRIPTION
The release.yml is copied from https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#the-whole-ci-cd-workflow, without the testpypi (no access) and GitHub release steps (will manual release on GitHub instead), which I assume should work.
Just want to make sure the changelog looks good to you all.