### PR TITLE
fix: check whether file exists before downloading the file by using stream parameter

### DIFF
--- a/src/onc/modules/_OncDelivery.py
+++ b/src/onc/modules/_OncDelivery.py
@@ -210,7 +210,7 @@ class _OncDelivery(_OncService):
             )
 
             if status == 200 or status == 777:
-                # file was downloaded (200), or downloaded & skipped (777)
+                # file was downloaded (200), or skipped before downloading (777)
                 fileList.append(dpf.getInfo())
                 index += 1
                 dpf = _DataProductFile(runId, str(index), baseUrl, token)


### PR DESCRIPTION
This PR fixes a bug that the client library should not download the file if the file exists and overwrite=False. Previosly, it downloads the file first, then checks if the file exists, which wastes bandwidth.

By using [stream=True](https://webscraping.ai/faq/requests/what-is-the-stream-parameter-in-requests-and-when-should-i-use-it) parameter, the requests method can postpone the download. `saveAsFile` will handle the actual stream download, and also return the download time and file size.

Initially I tried using [HEAD](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD) first to avoid the download. Turns out it requires a bigger code change (download the file in `status=200` branch). I also met some difficulties like HEAD does not have a body, so `status=202` cannot use response.json(). Using stream can keep the current code logic unchanged.

The test failure can be ignored. It is a backend bug, which will be fixed in the backend later.