### PR TITLE
Update new method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 onc is a Python client library that facilitates access to scientific data hosted by [Ocean Networks Canada](https://oceannetworks.ca)
 through the [Oceans 3.0 API](https://data.oceannetworks.ca/OpenAPI) public web services.
 It can help you explore and download our data, by consuming our
-_[discovery](https://oceannetworkscanada.github.io/api-python-client/API_Guide.html#discovery-methods)_,
-_[data product download](https://oceannetworkscanada.github.io/api-python-client/API_Guide.html#data-product-download-methods)_,
-_[archive file download](https://oceannetworkscanada.github.io/api-python-client/API_Guide.html#archive-file-download-methods)_, and
-_[near real-time data access](https://oceannetworkscanada.github.io/api-python-client/API_Guide.html#near-real-time-data-access-methods)_ services.
+_[discovery](https://oceannetworkscanada.github.io/Oceans3.0-API/API_Guide.html#discovery-methods)_,
+_[data product download](https://oceannetworkscanada.github.io/Oceans3.0-API/API_Guide.html#data-product-download-methods)_,
+_[archive file download](https://oceannetworkscanada.github.io/Oceans3.0-API/API_Guide.html#archive-file-download-methods)_, and
+_[near real-time data access](https://oceannetworkscanada.github.io/Oceans3.0-API/API_Guide.html#near-real-time-data-access-methods)_ services.
 
 # Getting Started
 
@@ -59,7 +59,7 @@ The example below uses the `getLocations` method to search for locations that in
 ```python
 from onc import ONC
 
-onc = ONC("YOUR_TOKEN_HERE")
+onc = ONC("YOUR_TOKEN")
 
 onc.getLocations({"locationName": "Burrard"})
 ```
@@ -74,7 +74,7 @@ onc.getDeviceCategories({"locationCode": "BIIP"})
 onc.getDataProducts({"locationCode": "BIIP", "deviceCategoryCode": "CTD"})
 ```
 
-Check more on the _[discovery methods guide](https://oceannetworkscanada.github.io/api-python-client/API_Guide.html#discovery-methods)_
+Check more on the _[discovery methods guide](https://oceannetworkscanada.github.io/Oceans3.0-API/API_Guide.html#discovery-methods)_
 and _[code examples](https://oceannetworkscanada.github.io/api-python-client/Code_Examples/index.html)_.
 
 ## Downloading data products
@@ -107,7 +107,7 @@ They also include a couple of filters to configure this specific data product ty
 which can be obtained from the [Data Product Options](https://wiki.oceannetworks.ca/display/DP/Data+Product+Options) documentation.
 You can download more than 120 different [types of data products](https://wiki.oceannetworks.ca/display/O2A/Available+Data+Products) including audio & video.
 
-Check more on the _[data product download methods guide](https://oceannetworkscanada.github.io/api-python-client/API_Guide.html#data-product-download-methods)_
+Check more on the _[data product download methods guide](https://oceannetworkscanada.github.io/Oceans3.0-API/API_Guide.html#data-product-download-methods)_
 and _[code examples](https://oceannetworkscanada.github.io/api-python-client/Code_Examples/Download_Data_Products.html)_.
 
 ## Obtaining sensor readings in (near) real-time
@@ -125,13 +125,16 @@ params = {
     "dateFrom": "2019-06-20T00:00:00.000Z",
     "dateTo": "2019-06-20T00:00:05.000Z",
 }
-onc.getDirectByLocation(params)
+onc.getScalardata(params)
+
+# Longer method name
+# onc.getScalardataByLocation(params)
 ```
 
 The result includes matching lists of "values" and "sampleTimes" (increases performance for long time ranges).
 We also use the property code "conductivity" to limit results to a specific property available in this CTD.
 
-Check more on the _[near real-time data access methods guide](https://oceannetworkscanada.github.io/api-python-client/API_Guide.html#near-real-time-data-access-methods)_
+Check more on the _[near real-time data access methods guide](https://oceannetworkscanada.github.io/Oceans3.0-API/API_Guide.html#near-real-time-data-access-methods)_
 and _[code examples](https://oceannetworkscanada.github.io/api-python-client/Code_Examples/Request_Real_Time_Data.html)_.
 
 ## Downloading archived files
@@ -149,16 +152,19 @@ params = {
     "dateFrom": "2016-12-01T00:00:00.000Z",
     "dateTo": "2016-12-01T00:05:00.000Z",
 }
-result = onc.getListByLocation(params, allPages=True)
+result = onc.getArchivefile(params, allPages=True)
 
-# download one of the files from result["files"]
-onc.getFile("AXISQ6044PTZACCC8E334C53_20161201T000001.000Z.jpg")
+# Longer method name
+# result = onc.getArchivefileByLocation(params, allPages=True)
+
+# Download one of the files from result["files"]
+onc.downloadArchivefile("AXISQ6044PTZACCC8E334C53_20161201T000001.000Z.jpg", overwrite=True)
 ```
 
-You can use the method `getFile()` as above to download individual files or the method `getDirectFiles()`
+You can use the method `downloadArchivefile()` as above to download individual files or the method `downloadDirectArchivefile()`
 to download all the files that match your filters.
 
-Check more on the _[archive file download methods guide](https://oceannetworkscanada.github.io/api-python-client/API_Guide.html#archive-file-download-methods)_
+Check more on the _[archive file download methods guide](https://oceannetworkscanada.github.io/Oceans3.0-API/API_Guide.html#archive-file-download-methods)_
 and _[code examples](https://oceannetworkscanada.github.io/api-python-client/Code_Examples/Download_Archived_Files.html)_.
 
 # Documentation

--- a/doc/source/Tutorial/onc_Library_Tutorial.ipynb
+++ b/doc/source/Tutorial/onc_Library_Tutorial.ipynb
@@ -391,7 +391,7 @@
    "source": [
     "### 2.1 Near real-time scalar data download\n",
     "\n",
-    "In this example we want to download one minute of **Pressure** sensor data from a **CTD** at location \"Bullseye\" (locationCode: **NC89**)\n"
+    "In this example we want to download 10 seconds of **Pressure** sensor data from a **CTD** at location \"Bullseye\" (locationCode: **NC89**)\n"
    ]
   },
   {
@@ -417,7 +417,7 @@
     "}\n",
     "\n",
     "# 2. Call methods in the onc library\n",
-    "r = onc.getDirectByLocation(params)\n",
+    "r = onc.getScalardata(params)  # getScalardataByLocation(params) also works\n",
     "\n",
     "# 3. Return the dictionary keys (fields) of the query to get a sense what is contained in your returned message\n",
     "print(r.keys())\n",
@@ -470,7 +470,7 @@
    "source": [
     "### 2.2 Near real-time raw data readings\n",
     "\n",
-    "In this example we want to download one minute of raw data from a **CTD** at location \"Bullseye\" (locationCode: **NC89**)\n"
+    "In this example we want to download 10 seconds of raw data from a **CTD** at location \"Bullseye\" (locationCode: **NC89**)\n"
    ]
   },
   {
@@ -495,7 +495,7 @@
     "}\n",
     "\n",
     "# 2. Call methods in the onc library\n",
-    "r = onc.getDirectRawByLocation(params)\n",
+    "r = onc.getRawdata(params)  # getRawdataByLocation(params) also works\n",
     "\n",
     "# 3. Return the dictionary keys (fields) of the query to get a sense what is contained in your returned message\n",
     "print(r.keys())\n",
@@ -549,7 +549,7 @@
     "\n",
     "1. If you use **onc**.\n",
     "\n",
-    "`getDirectRawByLocation` supports a boolean `allPages` parameter. When set to `True`, it will try to retrieve all the pages.\n",
+    "`getRawdata` supports a boolean `allPages` parameter. When set to `True`, it will try to retrieve all the pages.\n",
     "\n",
     "2. If you use **requests**.\n",
     "\n",
@@ -570,7 +570,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# 1. Define your filter parameter with a longer date range (2 days of data)\n",
+    "# 1. Define your filter parameter with a longer date range (1 day of data)\n",
     "params_longer_range = {\n",
     "    \"locationCode\": \"NC89\",\n",
     "    \"deviceCategoryCode\": \"CTD\",\n",
@@ -579,7 +579,9 @@
     "}\n",
     "\n",
     "# 2. Call methods in the onc library\n",
-    "r = onc.getDirectRawByLocation(params_longer_range, allPages=True)\n",
+    "r = onc.getRawdata(\n",
+    "    params_longer_range, allPages=True\n",
+    ")  # getRawdataByLocation(params_longer_range, allPages=True) also works\n",
     "\n",
     "# 3. Read it into a DataFrame\n",
     "pd.DataFrame(r[\"data\"])"
@@ -704,7 +706,7 @@
     "}\n",
     "\n",
     "# 2. Call methods in the onc library\n",
-    "r = onc.getListByLocation(params)\n",
+    "r = onc.getArchivefile(params)  # getArchivefileByLocation(params) also works\n",
     "\n",
     "# 3. This is the list of archived files:\n",
     "r[\"files\"]"
@@ -754,7 +756,7 @@
     }
    },
    "source": [
-    "Once we have the file names, you can use the method **\"getFile()\"** to download individual files:\n"
+    "Once we have the file names, you can use the method **\"downloadArchivefile()\"** to download individual files:\n"
    ]
   },
   {
@@ -770,8 +772,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# 1. Call methods in the onc library with the filename. The file is downloaded in the output folder.\n",
-    "onc.getFile(\"AXISQ6044PTZACCC8E334C53_20161201T000001.000Z.jpg\", overwrite=True)"
+    "# 1. Call methods in the onc library with the filename. The file is downloaded in the output folder by default,\n",
+    "# which can be customized in the outPath parameter of the ONC class.\n",
+    "onc.downloadArchivefile(\n",
+    "    \"AXISQ6044PTZACCC8E334C53_20161201T000001.000Z.jpg\", overwrite=True\n",
+    ")"
    ]
   },
   {
@@ -985,7 +990,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },

--- a/src/onc/modules/_OncArchive.py
+++ b/src/onc/modules/_OncArchive.py
@@ -21,16 +21,16 @@ class _OncArchive(_OncService):
         """
         Return a list of archived files for a device category in a location.
 
-        The filenames obtained can be used to download files using the getFile() method.
-        """
+        The filenames obtained can be used to download files using the ``downloadArchivefile`` method.
+        """  # noqa: E501
         return self._getList(filters, by="location", allPages=allPages)
 
     def getArchivefileByDevice(self, filters: dict, allPages: bool):
         """
         Return a list of archived files from a specific device.
 
-        The filenames obtained can be used to download files using the getFile() method.
-        """
+        The filenames obtained can be used to download files using the ``downloadArchivefile`` method.
+        """  # noqa: E501
         return self._getList(filters, by="device", allPages=allPages)
 
     def getArchivefile(self, filters: dict, allPages: bool):
@@ -84,8 +84,8 @@ class _OncArchive(_OncService):
         """
         Download a list of archived files that match the filters provided.
 
-        This function invokes the method getListByLocation() or getListByDevice()
-        to obtain a list of files, and the method getFile() to download all files found.
+        This function invokes the method ``getArchivefile`` to obtain a list of files,
+        and the method ``downloadArchivefile`` to download all files found.
 
         See https://wiki.oceannetworks.ca/display/O2A/archivefiles
         for usage and available filters.
@@ -150,7 +150,7 @@ class _OncArchive(_OncService):
 
     def _getList(self, filters: dict, by: str = "location", allPages: bool = False):
         """
-        Wraps archivefiles getListByLocation and getListByDevice methods
+        Wraps archivefiles getArchivefileByLocation and getArchivefileByDevice methods
         """
         url = self._serviceUrl("archivefiles")
         filters["token"] = self._config("token")

--- a/tests/archive_file/test_archivefile_device.py
+++ b/tests/archive_file/test_archivefile_device.py
@@ -23,31 +23,31 @@ def params_multiple_pages(params):
 def test_invalid_param_value(requester, params):
     params_invalid_param_value = params | {"deviceCode": "XYZ123"}
     with pytest.raises(requests.HTTPError, match=r"API Error 127"):
-        requester.getListByDevice(params_invalid_param_value)
+        requester.getArchivefile(params_invalid_param_value)
 
 
 def test_invalid_params_missing_required(requester, params):
     del params["deviceCode"]
-    with pytest.raises(requests.HTTPError, match=r"API Error 128"):
-        requester.getListByDevice(params)
+    with pytest.raises(ValueError):
+        requester.getArchivefile(params)
 
 
 def test_invalid_param_name(requester, params):
     params_invalid_param_name = params | {"deviceCodes": "BPR-Folger-59"}
     with pytest.raises(requests.HTTPError, match=r"API Error 129"):
-        requester.getListByDevice(params_invalid_param_name)
+        requester.getArchivefile(params_invalid_param_name)
 
 
 def test_no_data(requester, params):
     params_no_data = params | {"dateFrom": "2000-01-01", "dateTo": "2000-01-02"}
-    data = requester.getListByDevice(params_no_data)
+    data = requester.getArchivefile(params_no_data)
 
     assert len(data["files"]) == 0
 
 
 def test_valid_params_one_page(requester, params, params_multiple_pages):
-    data = requester.getListByDevice(params)
-    data_all_pages = requester.getListByDevice(params_multiple_pages, allPages=True)
+    data = requester.getArchivefile(params)
+    data_all_pages = requester.getArchivefile(params_multiple_pages, allPages=True)
 
     assert (
         len(data["files"]) > params_multiple_pages["rowLimit"]
@@ -63,7 +63,7 @@ def test_valid_params_one_page(requester, params, params_multiple_pages):
 
 
 def test_valid_params_multiple_pages(requester, params_multiple_pages):
-    data = requester.getListByDevice(params_multiple_pages)
+    data = requester.getArchivefile(params_multiple_pages)
 
     assert (
         len(data["files"]) == params_multiple_pages["rowLimit"]

--- a/tests/archive_file/test_archivefile_direct_download.py
+++ b/tests/archive_file/test_archivefile_direct_download.py
@@ -1,6 +1,6 @@
 def test_valid_params_one_page(requester, params_location, util):
-    data = requester.getListByLocation(params_location)
-    result = requester.getDirectFiles(params_location)
+    data = requester.getArchivefile(params_location)
+    result = requester.downloadDirectArchivefile(params_location)
 
     assert util.get_download_files_num(requester) == len(data["files"])
 
@@ -8,7 +8,7 @@ def test_valid_params_one_page(requester, params_location, util):
 
 
 def test_valid_params_multiple_pages(requester, params_location_multiple_pages, util):
-    result = requester.getDirectFiles(params_location_multiple_pages)
+    result = requester.downloadDirectArchivefile(params_location_multiple_pages)
 
     assert (
         util.get_download_files_num(requester)

--- a/tests/archive_file/test_archivefile_download.py
+++ b/tests/archive_file/test_archivefile_download.py
@@ -4,24 +4,24 @@ import requests
 
 def test_invalid_param_value(requester):
     with pytest.raises(requests.HTTPError, match=r"API Error 96"):
-        requester.getFile("FAKEFILE.XYZ")
+        requester.downloadArchivefile("FAKEFILE.XYZ")
 
 
 def test_invalid_params_missing_required(requester):
     with pytest.raises(requests.HTTPError, match=r"API Error 128"):
-        requester.getFile()
+        requester.downloadArchivefile()
 
 
 def test_valid_params(requester, util):
     filename = "BPR-Folger-59_20191123T000000.000Z.txt"
 
-    requester.getFile(filename)
+    requester.downloadArchivefile(filename)
 
     assert (requester.outPath / filename).exists()
 
     with pytest.raises(FileExistsError):
-        requester.getFile(filename)
+        requester.downloadArchivefile(filename)
 
-    requester.getFile(filename, overwrite=True)
+    requester.downloadArchivefile(filename, overwrite=True)
 
     assert util.get_download_files_num(requester) == 1

--- a/tests/archive_file/test_archivefile_location.py
+++ b/tests/archive_file/test_archivefile_location.py
@@ -5,19 +5,19 @@ import requests
 def test_invalid_param_value(requester, params_location):
     params_invalid_param_value = params_location | {"locationCode": "XYZ123"}
     with pytest.raises(requests.HTTPError, match=r"API Error 127"):
-        requester.getListByLocation(params_invalid_param_value)
+        requester.getArchivefile(params_invalid_param_value)
 
 
 def test_invalid_params_missing_required(requester, params_location):
     del params_location["locationCode"]
-    with pytest.raises(requests.HTTPError, match=r"API Error 128"):
-        requester.getListByLocation(params_location)
+    with pytest.raises(ValueError):
+        requester.getArchivefile(params_location)
 
 
 def test_invalid_param_name(requester, params_location):
     params_invalid_param_name = params_location | {"locationCodes": "NCBC"}
     with pytest.raises(requests.HTTPError, match=r"API Error 129"):
-        requester.getListByLocation(params_invalid_param_name)
+        requester.getArchivefile(params_invalid_param_name)
 
 
 def test_no_data(requester, params_location):
@@ -26,14 +26,14 @@ def test_no_data(requester, params_location):
         "dateTo": "2000-01-02",
     }
     with pytest.raises(requests.HTTPError, match=r"API Error 127"):
-        requester.getListByLocation(params_no_data)
+        requester.getArchivefile(params_no_data)
 
 
 def test_valid_params_one_page(
     requester, params_location, params_location_multiple_pages
 ):
-    data = requester.getListByLocation(params_location)
-    data_all_pages = requester.getListByLocation(
+    data = requester.getArchivefile(params_location)
+    data_all_pages = requester.getArchivefile(
         params_location_multiple_pages, allPages=True
     )
 
@@ -51,7 +51,7 @@ def test_valid_params_one_page(
 
 
 def test_valid_params_multiple_pages(requester, params_location_multiple_pages):
-    data = requester.getListByLocation(params_location_multiple_pages)
+    data = requester.getArchivefile(params_location_multiple_pages)
 
     assert (
         len(data["files"]) == params_location_multiple_pages["rowLimit"]

--- a/tests/discover_locations/test_locations_tree.py
+++ b/tests/discover_locations/test_locations_tree.py
@@ -9,7 +9,7 @@ def test_invalid_time_range_greater_start_time(requester):
         "dateTo": "2019-01-01",
     }
     with pytest.raises(requests.HTTPError, match=r"API Error 23"):
-        requester.getLocationHierarchy(params_invalid_time_range_greater_start_time)
+        requester.getLocationsTree(params_invalid_time_range_greater_start_time)
 
 
 def test_invalid_time_range_future_start_time(requester):
@@ -18,25 +18,25 @@ def test_invalid_time_range_future_start_time(requester):
         "dateFrom": "2050-01-01",
     }
     with pytest.raises(requests.HTTPError, match=r"API Error 25"):
-        requester.getLocationHierarchy(params_invalid_time_range_future_start_time)
+        requester.getLocationsTree(params_invalid_time_range_future_start_time)
 
 
 def test_invalid_param_value(requester):
     params_invalid_param_value = {"locationCode": "XYZ123"}
     with pytest.raises(requests.HTTPError, match=r"API Error 127"):
-        requester.getLocationHierarchy(params_invalid_param_value)
+        requester.getLocationsTree(params_invalid_param_value)
 
 
 def test_invalid_param(requester):
     params_invalid_param_name = {"locationCodes": "ARCT"}
     with pytest.raises(requests.HTTPError, match=r"API Error 129"):
-        requester.getLocationHierarchy(params_invalid_param_name)
+        requester.getLocationsTree(params_invalid_param_name)
 
 
 def test_no_data(requester):
     params_no_data = {"locationCode": "ARCT", "dateTo": "1900-01-01"}
     with pytest.raises(requests.HTTPError, match=r"404 Client Error"):
-        requester.getLocationHierarchy(params_no_data)
+        requester.getLocationsTree(params_no_data)
 
 
 def test_valid_params(requester, util):
@@ -50,7 +50,7 @@ def test_valid_params(requester, util):
         "hasPropertyData": bool,
     }
 
-    data = requester.getLocationHierarchy(params)
+    data = requester.getLocationsTree(params)
 
     assert len(data) > 0, "Valid locations tree test should return at least 1 row."
 

--- a/tests/raw_data/test_rawdata_device.py
+++ b/tests/raw_data/test_rawdata_device.py
@@ -21,27 +21,25 @@ def params_multiple_pages(params):
 def test_invalid_param_value(requester, params):
     params_invalid_param_value = params | {"deviceCode": "XYZ123"}
     with pytest.raises(requests.HTTPError, match=r"API Error 127"):
-        requester.getDirectRawByDevice(params_invalid_param_value)
+        requester.getRawdata(params_invalid_param_value)
 
 
 def test_invalid_param_name(requester, params):
     params_invalid_param_name = params | {"deviceCodes": "BPR-Folger-59"}
     with pytest.raises(requests.HTTPError, match=r"API Error 129"):
-        requester.getDirectRawByDevice(params_invalid_param_name)
+        requester.getRawdata(params_invalid_param_name)
 
 
 def test_no_data(requester, params):
     params_no_data = params | {"dateFrom": "2000-01-01", "dateTo": "2000-01-02"}
-    data = requester.getDirectRawByDevice(params_no_data)
+    data = requester.getRawdata(params_no_data)
 
     assert _get_row_num(data) == 0
 
 
 def test_valid_params_one_page(requester, params, params_multiple_pages):
-    data = requester.getDirectRawByDevice(params)
-    data_all_pages = requester.getDirectRawByDevice(
-        params_multiple_pages, allPages=True
-    )
+    data = requester.getRawdata(params)
+    data_all_pages = requester.getRawdata(params_multiple_pages, allPages=True)
 
     assert (
         _get_row_num(data) > params_multiple_pages["rowLimit"]
@@ -57,7 +55,7 @@ def test_valid_params_one_page(requester, params, params_multiple_pages):
 
 
 def test_valid_params_multi_pages(requester, params_multiple_pages):
-    data = requester.getDirectRawByDevice(params_multiple_pages)
+    data = requester.getRawdata(params_multiple_pages)
 
     assert (
         _get_row_num(data) == params_multiple_pages["rowLimit"]

--- a/tests/raw_data/test_rawdata_location.py
+++ b/tests/raw_data/test_rawdata_location.py
@@ -24,26 +24,24 @@ def params_multiple_pages(params):
 def test_invalid_param_value(requester, params):
     params_invalid_param_value = params | {"locationCode": "XYZ123"}
     with pytest.raises(requests.HTTPError, match=r"API Error 127"):
-        requester.getDirectRawByLocation(params_invalid_param_value)
+        requester.getRawdata(params_invalid_param_value)
 
 
 def test_invalid_param_name(requester, params):
     params_invalid_param_name = params | {"locationCodes": "NCBC"}
     with pytest.raises(requests.HTTPError, match=r"API Error 129"):
-        requester.getDirectRawByLocation(params_invalid_param_name)
+        requester.getRawdata(params_invalid_param_name)
 
 
 def test_no_data(requester, params):
     params_no_data = params | {"dateFrom": "2000-01-01", "dateTo": "2000-01-02"}
     with pytest.raises(requests.HTTPError, match=r"API Error 127"):
-        requester.getDirectRawByLocation(params_no_data)
+        requester.getRawdata(params_no_data)
 
 
 def test_valid_params_one_page(requester, params, params_multiple_pages):
-    data = requester.getDirectRawByLocation(params)
-    data_all_pages = requester.getDirectRawByLocation(
-        params_multiple_pages, allPages=True
-    )
+    data = requester.getRawdata(params)
+    data_all_pages = requester.getRawdata(params_multiple_pages, allPages=True)
 
     assert (
         _get_row_num(data) > params_multiple_pages["rowLimit"]
@@ -59,7 +57,7 @@ def test_valid_params_one_page(requester, params, params_multiple_pages):
 
 
 def test_valid_params_multiple_pages(requester, params_multiple_pages):
-    data = requester.getDirectRawByLocation(params_multiple_pages)
+    data = requester.getRawdata(params_multiple_pages)
 
     assert (
         _get_row_num(data) == params_multiple_pages["rowLimit"]

--- a/tests/regression/code_examples.py
+++ b/tests/regression/code_examples.py
@@ -4,8 +4,10 @@ from pathlib import Path
 
 import pytest
 
-markdown_dir = Path(__file__).parent.parent.parent / "doc/source/Code_Examples"
+base_path = Path(__file__).parent.parent.parent
+markdown_dir = base_path / "doc/source/Code_Examples"
 markdowns = [md for md in markdown_dir.glob("*.md") if md.name != "index.md"]
+markdowns.append(base_path / "README.md")
 
 
 @pytest.mark.parametrize("markdown", markdowns)

--- a/tests/regression/doctest.py
+++ b/tests/regression/doctest.py
@@ -75,7 +75,7 @@ def test_get_locations_tree(requester):
         }
     ]
 
-    assert requester.getLocationHierarchy(params) == result
+    assert requester.getLocationsTree(params) == result
 
 
 def test_get_deployments(requester):

--- a/tests/scalar_data/test_scalardata_device.py
+++ b/tests/scalar_data/test_scalardata_device.py
@@ -11,25 +11,25 @@ def params_multiple_pages(params_device):
 def test_invalid_param_value(requester, params_device):
     params_invalid_param_value = params_device | {"deviceCode": "XYZ123"}
     with pytest.raises(requests.HTTPError, match=r"API Error 127"):
-        requester.getDirectByDevice(params_invalid_param_value)
+        requester.getScalardata(params_invalid_param_value)
 
 
 def test_invalid_param_name(requester, params_device):
     params_invalid_param_name = params_device | {"deviceCodes": "BPR-Folger-59"}
     with pytest.raises(requests.HTTPError, match=r"API Error 129"):
-        requester.getDirectByDevice(params_invalid_param_name)
+        requester.getScalardata(params_invalid_param_name)
 
 
 def test_no_data(requester, params_device):
     params_no_data = params_device | {"dateFrom": "2000-01-01", "dateTo": "2000-01-02"}
-    data = requester.getDirectByDevice(params_no_data)
+    data = requester.getScalardata(params_no_data)
 
     assert data["sensorData"] is None
 
 
 def test_valid_params_one_page(requester, params_device, params_multiple_pages):
-    data = requester.getDirectByDevice(params_device)
-    data_all_pages = requester.getDirectByDevice(params_multiple_pages, allPages=True)
+    data = requester.getScalardata(params_device)
+    data_all_pages = requester.getScalardata(params_multiple_pages, allPages=True)
 
     assert (
         _get_row_num(data) > params_multiple_pages["rowLimit"]
@@ -45,7 +45,7 @@ def test_valid_params_one_page(requester, params_device, params_multiple_pages):
 
 
 def test_valid_params_multiple_pages(requester, params_multiple_pages):
-    data = requester.getDirectByDevice(params_multiple_pages)
+    data = requester.getScalardata(params_multiple_pages)
 
     assert (
         _get_row_num(data) == params_multiple_pages["rowLimit"]

--- a/tests/scalar_data/test_scalardata_location.py
+++ b/tests/scalar_data/test_scalardata_location.py
@@ -11,13 +11,13 @@ def params_multiple_pages(params_location):
 def test_invalid_param_value(requester, params_location):
     params_invalid_param_value = params_location | {"locationCode": "XYZ123"}
     with pytest.raises(requests.HTTPError, match=r"API Error 127"):
-        requester.getDirectByLocation(params_invalid_param_value)
+        requester.getScalardata(params_invalid_param_value)
 
 
 def test_invalid_param_name(requester, params_location):
     params_invalid_param_name = params_location | {"locationCodes": "NCBC"}
     with pytest.raises(requests.HTTPError, match=r"API Error 129"):
-        requester.getDirectByLocation(params_invalid_param_name)
+        requester.getScalardata(params_invalid_param_name)
 
 
 def test_no_data(requester, params_location):
@@ -26,12 +26,12 @@ def test_no_data(requester, params_location):
         "dateTo": "2000-01-02",
     }
     with pytest.raises(requests.HTTPError, match=r"API Error 127"):
-        requester.getDirectByLocation(params_no_data)
+        requester.getScalardata(params_no_data)
 
 
 def test_valid_params_one_page(requester, params_location, params_multiple_pages):
-    data = requester.getDirectByLocation(params_location)
-    data_all_pages = requester.getDirectByLocation(params_multiple_pages, allPages=True)
+    data = requester.getScalardata(params_location)
+    data_all_pages = requester.getScalardata(params_multiple_pages, allPages=True)
 
     assert (
         _get_row_num(data) > params_multiple_pages["rowLimit"]
@@ -47,7 +47,7 @@ def test_valid_params_one_page(requester, params_location, params_multiple_pages
 
 
 def test_valid_params_multiple_pages(requester, params_multiple_pages):
-    data = requester.getDirectByLocation(params_multiple_pages)
+    data = requester.getScalardata(params_multiple_pages)
 
     assert (
         _get_row_num(data) == params_multiple_pages["rowLimit"]


### PR DESCRIPTION
This PR updates the method names in other places of the documentation, and the tests folder.
The list of new and old method names are listed in https://oceannetworkscanada.github.io/api-python-client/changelog.html#enhancements.
Also found a small issue in the README file. The API guide link has been extracted out of the python client library documentation site to include MATLAB, but the links were not updated.