### PR TITLE
Issue 60 ignore timezone

### DIFF
--- a/src/onc/modules/_MultiPage.py
+++ b/src/onc/modules/_MultiPage.py
@@ -135,8 +135,12 @@ class _MultiPage:
             return 0
 
         # total timespan to cover in the next parameter excluding the first page
-        totalBegin = dateutil.parser.parse(response["next"]["parameters"]["dateFrom"])
-        totalEnd = dateutil.parser.parse(response["next"]["parameters"]["dateTo"])
+        totalBegin = dateutil.parser.parse(
+            response["next"]["parameters"]["dateFrom"], ignoretz=True
+        )
+        totalEnd = dateutil.parser.parse(
+            response["next"]["parameters"]["dateTo"], ignoretz=True
+        )
         totalTimespan = totalEnd - totalBegin
 
         # handle cases of very small timeframes

--- a/src/onc/onc.py
+++ b/src/onc/onc.py
@@ -53,7 +53,7 @@ class ONC:
         token,
         production: bool = True,
         showInfo: bool = False,
-        showWarning: bool = True,
+        showWarning: bool = False,
         outPath: str | Path = "output",
         timeout: int = 60,
     ):

--- a/tests/raw_data/test_rawdata_device.py
+++ b/tests/raw_data/test_rawdata_device.py
@@ -37,6 +37,14 @@ def test_no_data(requester, params):
     assert _get_row_num(data) == 0
 
 
+def test_different_date_format_all_pages(requester, params_multiple_pages):
+    params_different_date_format = params_multiple_pages | {
+        "dateFrom": "2019-11-23T23:59:00.000Z",
+        "dateTo": "2019-11-24",
+    }
+    requester.getRawdata(params_different_date_format, allPages=True)
+
+
 def test_valid_params_one_page(requester, params, params_multiple_pages):
     data = requester.getRawdata(params)
     data_all_pages = requester.getRawdata(params_multiple_pages, allPages=True)

--- a/tests/scalar_data/test_scalardata_device.py
+++ b/tests/scalar_data/test_scalardata_device.py
@@ -27,6 +27,14 @@ def test_no_data(requester, params_device):
     assert data["sensorData"] is None
 
 
+def test_different_date_format_all_pages(requester, params_multiple_pages):
+    params_different_date_format = params_multiple_pages | {
+        "dateFrom": "2019-11-23T23:59:00.000Z",
+        "dateTo": "2019-11-24",
+    }
+    requester.getScalardata(params_different_date_format, allPages=True)
+
+
 def test_valid_params_one_page(requester, params_device, params_multiple_pages):
     data = requester.getScalardata(params_device)
     data_all_pages = requester.getScalardata(params_multiple_pages, allPages=True)


### PR DESCRIPTION
Partially fix #60 

Besides the standard "YYYY-MM-DDTHH:MM:SS.SSSZ", the backend also supports "YYYY-MM-DD" and ISO 8601 duration format like "PT1M". This Pr does not fix the duration format. so this works
```python
onc.getRawdata(
    {
        "deviceCategoryCode": "ACOUSTICTRANSPONDER",
        "dateFrom": "2025-04-01T23:59:00.000Z",
        "dateTo": "2025-04-02",
        "locationCode": "BACSG.AT1",
        "rowLimit":"3",
    },
    allPages=True,
)
```
but this does not work
```python
onc.getRawdata(
    {
        "deviceCategoryCode": "ACOUSTICTRANSPONDER",
        "dateFrom": "2025-04-01T23:59:00.000Z",
        "dateTo": "PT1M",
        "locationCode": "BACSG.AT1",
        "rowLimit":"3",
    },
    allPages=True,
)
```
In fact `getScarlardata` changes those datetimes to the standard format (the second example works if changing `getRawdata` to `getScarlardata`), so getRawdata should also do that. I will ask the developer to fix it.

I also changed the default value of `showWarning` to `False`. This is requested by our internal manager. Our backend gives some unexpected warnings, which confuses users. Turning it off until the issue is fixed.